### PR TITLE
Make 'clean' should remove packer-*-out.log 

### DIFF
--- a/provisioning/Makefile
+++ b/provisioning/Makefile
@@ -16,4 +16,4 @@ vbox:
 	packer build -only=virtualbox-iso $(JSON) 2>&1 | tee packer-$@-out.log
 
 clean:
-	rm -rf build packer-vbox-out.log packer.log
+	rm -rf build packer-*-out.log packer.log


### PR DESCRIPTION
So that ec2 and any future other build-specific logs are removed. Or it could just include specific log file for ec2 if that's preferred.
