### PR TITLE
Make 'clean' should remove packer_cache

### DIFF
--- a/provisioning/Makefile
+++ b/provisioning/Makefile
@@ -16,4 +16,4 @@ vbox:
 	packer build -only=virtualbox-iso $(JSON) 2>&1 | tee packer-$@-out.log
 
 clean:
-	rm -rf build packer-*-out.log packer.log
+	rm -rf build packer_cache packer-*-out.log packer.log


### PR DESCRIPTION
The packer_cache directory should be removed by make "clean" if it exists, because it will contain the Ubuntu iso file (600mb+) if the build stopped.
