### PR TITLE
Expand ec2 instructions

### DIFF
--- a/provisioning/HOWTO.md
+++ b/provisioning/HOWTO.md
@@ -18,9 +18,16 @@ For a Virtualbox VM, run:
 
 This creates a virtual machine in the OVA format that can be imported into Virtualbox on Windows, Mac, or UNIX.
 
-To create an Amazon EC2 AMI, set your Amazon security credentials in 'BCE-14.04-amd64-ec2.json' and then run:
+To create an Amazon EC2 AMI, set your Amazon security credentials and then run:
 
     $ make ec2
+
+Amazon credentials can be set on the command line or by editing the BCE json file. To set on the command line run:
+
+    $ export AWS_ACCESS_KEY_ID=YYY
+    $ export AWS_SECRET_ACCESS_KEY=ZZZ
+
+More information on building to ec2 is available on the [packer ec2 help page](https://www.packer.io/docs/builders/amazon-ebs.html)
 
 Note that currently when you start up a VM from the resulting AMI, you'll need to first login as the 'ubuntu' user and set up SSH keys for the 'oski' user, which is the user provisioned by BCE.
 


### PR DESCRIPTION
Show the commands to set EC2 credentials on the command line and link to the relevant packer page.
