### PR TITLE
Update BCE version to 2015-summer

### DIFF
--- a/provisioning/bootstrap.d/00-init
+++ b/provisioning/bootstrap.d/00-init
@@ -9,7 +9,7 @@ export APT_GET="apt-get -q -y"
 export BCE_USER=oski
 
 # Make the BCE version available to downstream
-export BCE_VERSION="2015-spring"
+export BCE_VERSION="2015-summer"
 echo "BCE_VERSION=${BCE_VERSION}" >> /etc/environment
 
 echo "Environment:"


### PR DESCRIPTION
Not sure if there is a more central place to update/maintain the BCE _VERSION variable - e.g. using the JSON var from the original Makefile.
