### PR TITLE
Build AMI from US-west-2 rather than 1, to save 13%

### DIFF
--- a/provisioning/BCE-2015-summer.json
+++ b/provisioning/BCE-2015-summer.json
@@ -9,7 +9,7 @@
       "type": "amazon-ebs",
       "ami_name": "BCE-2015-summer-preview",
       "instance_type": "m3.medium",
-      "region": "us-west-1",
+      "region": "us-west-2",
       "ami_regions": "us-west-2",
       "source_ami": "ami-01717d44",
       "ssh_username": "ubuntu",


### PR DESCRIPTION
m3.medium is $0.077/hr in Northern California and $0.067/hr in Oregon, with similar pricing advantages for other instance types. (http://aws.amazon.com/ec2/pricing/)

Could also be cool to eventually use the spot pricing option for packer (just do spot_price="auto"):
https://www.packer.io/docs/builders/amazon-ebs.html#spot_price
