### PR TITLE
Convert MRAN to https in Rprofile

### DIFF
--- a/provisioning/bootstrap.d/70-r
+++ b/provisioning/bootstrap.d/70-r
@@ -20,7 +20,11 @@ echo "  DONE" || echo "  FAIL"
 
 msg="BCE: Define our R repository."
 echo "$msg"
-echo "options(repos = list(CRAN = '${R_REPO}'))" >> /etc/R/Rprofile.site && \
+
+# Use HTTPS for RProfile to prevent an error message in RStudio.
+R_REPO_HTTPS = ${R_REPO//http:/^https}:
+
+echo "options(repos = list(CRAN = '${R_REPO_HTTPS}'))" >> /etc/R/Rprofile.site && \
 ( echo "  DONE" ; etckeeper commit "$msg" ) || echo "  FAIL"
 
 msg="BCE: Install R packages."


### PR DESCRIPTION
Resolve Rstudio error in #55. I've tested this on the EC2 build and it works. It should work fine for virtualbox but I haven't checked it.

I couldn't get the MRAN URL at the top of the file switched to https easily (gpg errors on apt-get) so I went with this regex approach.
